### PR TITLE
Added --short-pins option to generate.sh and kicadlibgen.py

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -4,5 +4,5 @@ git submodule init
 git submodule update
 
 cd script
-./kicadlibgen.py
+./kicadlibgen.py $@
 cd -

--- a/script/kicadlibgen.py
+++ b/script/kicadlibgen.py
@@ -5,6 +5,7 @@ __author__ = 'esdentem'
 
 import xml.etree.ElementTree
 import re
+import sys
 import StringIO
 # import os
 import glob
@@ -247,10 +248,11 @@ def lib_symbol(f, source_tree):
         pin_name = pin_data.attrib["Name"].replace(" ", "")
         pin_type = pin_data.attrib["Type"]
         pin_functions = []
-        for pin_function in pin_data.findall("Signal"):
-            pf_name = pin_function.attrib["Name"]
-            if pf_name != None and pf_name != "GPIO":
-                pin_functions.append(pf_name)
+        if not '--short-pins' in sys.argv:
+            for pin_function in pin_data.findall("Signal"):
+                pf_name = pin_function.attrib["Name"]
+                if pf_name != None and pf_name != "GPIO":
+                    pin_functions.append(pf_name)
         pin_append_combine(data, {'Pin': pin,
                                   'Pin_name': pin_name,
                                   'Pin_functions': pin_functions,


### PR DESCRIPTION
Added --short-pins command line option to generate.sh and kicadlibgen.py for short pin names.

Usage:
./generate.sh --short-pins

Will generate stm32.lib with only default pin name, like PA1 or VDD.